### PR TITLE
Upgrade forge to 41.1.0 + small workaround against crushes on M1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mod_name=CoFH Core
 mod_version=10.0.0
 
 mc_version=1.19
-forge_version=41.0.98
+forge_version=41.1.0
 
 jei_version=11.0.0.214
 curios_version=1.19-5.1.0.4

--- a/src/main/java/cofh/core/command/SubCommandCrafting.java
+++ b/src/main/java/cofh/core/command/SubCommandCrafting.java
@@ -15,7 +15,7 @@ public class SubCommandCrafting {
 
     public static Supplier<Integer> permissionLevel = () -> 2;
 
-    static final MutableComponent TITLE = Component.translatable("container.crafting");
+    static final MutableComponent TITLE = Component.literal("container.crafting");
 
     static ArgumentBuilder<CommandSourceStack, ?> register() {
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -27,6 +27,6 @@ side = "BOTH"
 [[dependencies.cofh_core]]
 modId = "forge"
 mandatory = true
-versionRange = "[41.0.43,)"
+versionRange = "[41.1.0,)"
 ordering = "AFTER"
 side = "BOTH"


### PR DESCRIPTION
Trying to build ThermalExpansion for 1.19 to have it running native on M1. Since some dependencies are rarely for 1.19.[1,2] stick with latest forge.