### PR TITLE
Fix IngredientWithCount causing disconnect with some custom ingredients

### DIFF
--- a/src/main/java/cofh/core/CoFHCore.java
+++ b/src/main/java/cofh/core/CoFHCore.java
@@ -28,6 +28,7 @@ import cofh.lib.loot.TileNBTSync;
 import cofh.lib.network.PacketHandler;
 import cofh.lib.util.DeferredRegisterCoFH;
 import cofh.lib.util.Utils;
+import cofh.lib.util.crafting.CustomIngredients;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.resources.ResourceLocation;
@@ -231,6 +232,7 @@ public class CoFHCore {
         event.enqueueWork(TileNBTSync::setup);
         event.enqueueWork(ArmorEvents::setup);
         event.enqueueWork(CoreFluids::setup);
+        event.enqueueWork(CustomIngredients::setup);
     }
 
     private void clientSetup(final FMLClientSetupEvent event) {

--- a/src/main/java/cofh/lib/util/crafting/CustomIngredients.java
+++ b/src/main/java/cofh/lib/util/crafting/CustomIngredients.java
@@ -1,0 +1,13 @@
+package cofh.lib.util.crafting;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.common.crafting.CraftingHelper;
+
+import static cofh.lib.util.constants.ModIds.ID_COFH_CORE;
+
+public class CustomIngredients {
+    public static void setup() {
+
+        CraftingHelper.register(new ResourceLocation(ID_COFH_CORE, "with_count"), IngredientWithCount.Serializer.INSTANCE);
+    }
+}

--- a/src/main/java/cofh/lib/util/crafting/IngredientWithCount.java
+++ b/src/main/java/cofh/lib/util/crafting/IngredientWithCount.java
@@ -91,7 +91,7 @@ public class IngredientWithCount extends AbstractIngredient {
         @Override
         public IngredientWithCount parse(JsonObject json) {
 
-            throw new JsonSyntaxException("IngredientWithCount should not be parsed using the serializer, use RecipeJsonUtils instead!");
+            throw new JsonSyntaxException("IngredientWithCount should not be parsed from JSON using the serializer, if you are a modder, use RecipeJsonUtils instead!");
         }
 
         @Override

--- a/src/main/java/cofh/lib/util/crafting/IngredientWithCount.java
+++ b/src/main/java/cofh/lib/util/crafting/IngredientWithCount.java
@@ -1,12 +1,14 @@
 package cofh.lib.util.crafting;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.AbstractIngredient;
 import net.minecraftforge.common.crafting.IIngredientSerializer;
-import net.minecraftforge.common.crafting.VanillaIngredientSerializer;
 
 import javax.annotation.Nullable;
 
@@ -67,7 +69,7 @@ public class IngredientWithCount extends AbstractIngredient {
     @Override
     public IIngredientSerializer<? extends Ingredient> getSerializer() {
 
-        return wrappedIngredient.isVanilla() ? VanillaIngredientSerializer.INSTANCE : wrappedIngredient.getSerializer();
+        return Serializer.INSTANCE;
     }
 
     @Override
@@ -76,4 +78,28 @@ public class IngredientWithCount extends AbstractIngredient {
         return wrappedIngredient.toJson();
     }
 
+    public static class Serializer implements IIngredientSerializer<IngredientWithCount> {
+
+        public static final Serializer INSTANCE = new Serializer();
+
+        @Override
+        public IngredientWithCount parse(FriendlyByteBuf buffer) {
+
+            return new IngredientWithCount(Ingredient.fromNetwork(buffer), buffer.readVarInt());
+        }
+
+        @Override
+        public IngredientWithCount parse(JsonObject json) {
+
+            throw new JsonSyntaxException("IngredientWithCount should not be parsed using the serializer, use RecipeJsonUtils instead!");
+        }
+
+        @Override
+        public void write(FriendlyByteBuf buffer, IngredientWithCount ingredient) {
+
+            ingredient.wrappedIngredient.toNetwork(buffer);
+            buffer.writeVarInt(ingredient.count);
+        }
+
+    }
 }


### PR DESCRIPTION
Because IngredientWithCount currently just uses the underlying ingredient's serialiser, this might cause issues in a scenario where the Serializer has an additional generic constraint on what kinds of ingredients are allowed, for example like this:

```java
class Serializer<T extends MyIngredient>() { } // note that T needs to extend *MyIngredient*

// elsewhere in code
ingredientWithCount.getSerializer() // returns the constrained serialiser
                   .write(buf, ingredientWithCount) // the method write only accepts MyIngredient, of which IngredientWithCount is not a subclass
``` 

There are multiple ways to fix this in theory, but the easiest one was to just create a serialiser class for IngredientWithCount that is network-only (since IngredientWithCount should not be used within JSON, that is handled by RecipeJsonUtils instead) and register that like any other ingredient serialiser using CraftingHelper ^^

Still needs a quick test in practice, but I've already asked some pack developers who have been having issues with Thermal and KubeJS to try a locally-compiled version for me